### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/yuscii.opam
+++ b/yuscii.opam
@@ -17,7 +17,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "fmt"
   "uutf"
   "rresult"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.